### PR TITLE
Patch i18n path lookup function to fix build

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -52,7 +52,9 @@ build() {
 
   cd electron-app
   npx asar extract app.asar app.asar.contents
-  sed -i 's|function RIe() {.*return x.app.isPackaged ? mn.resourcesPath : De.resolve(__dirname, "..", "..", "resources")|function RIe() { return "/usr/lib/'"${pkgname}"'/resources"|' app.asar.contents/.vite/build/index.js
+  sed -i 's|function RIe(){return x.app.isPackaged?mn.resourcesPath:De.resolve(__dirname,"..","..","resources")|function RIe() { return "/usr/lib/'"${pkgname}"'/resources"|' app.asar.contents/.vite/build/index.js
+  # note that the below is replacing i18n with the standard resources directory as that's where the i18n json files wind up
+  sed -i 's|function HD(){return x.app.isPackaged?process.resourcesPath:Ee.resolve(__dirname,"..","..","resources","i18n")|function HD() { return "/usr/lib/'"${pkgname}"'/resources"|' app.asar.contents/.vite/build/index.js
 
   # Replace native bindings with patchy-cnb
   pwd

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ The package build follows these steps:
 
    - Builds the `patchy-cnb` library from source using Rust
    - Replaces Windows-specific `.node` native modules with the newly compiled `patchy-cnb` ones
-   - Replaces the `RIe()` function of the `.vite/build/index.js` with one that simply returns the absolute path of the resources folder within the applications directory
+   - Replaces the `RIe()` and `HD()` functions of the `.vite/build/index.js` with ones that simply return the absolute path of the resources folder within the applications directory
 
 4. **Packaging Phase**:
    - Organizes files into the proper directory structure


### PR DESCRIPTION
Adds an additional `sed` command that patches a second function the desktop code uses to look up its i18n files. It's worth noting that the path the original code looks for is in the `i18n` subdirectory, but the files themselves wind up in the normal resources directory. Since it doesn't really matter where they wind up as long as we can find them, I didn't dig into that, but it seems worth noting in case something changes in the build down the line.

Fixes https://github.com/claude-desktop-native/claude-desktop-native/issues/1.